### PR TITLE
#7 Delegate status width changes

### DIFF
--- a/containers/delegates/columns/status.tsx
+++ b/containers/delegates/columns/status.tsx
@@ -13,7 +13,7 @@ import { DelegateAccountData } from "@Types"
 export const status = {
   align: "left",
   value: "Status",
-  width: "180px",
+  width: "190px",
   format: (delegate: DelegateAccountData, forgers: ForgersDataType[]) => {
     if (delegate?.dpos?.delegate?.isBanned) {
       return (


### PR DESCRIPTION
#7 changed status column width from 180px to 190px to stop long text from stretching the column on update